### PR TITLE
重複するファイルも保持できるようにした。

### DIFF
--- a/controller/serverController.go
+++ b/controller/serverController.go
@@ -2,14 +2,16 @@ package controller
 
 import (
 	"fmt"
+	"math/rand"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
 
 type ServerController struct {
-	Main      *MainController
-	FileNames map[string]string
+	Main        *MainController
+	LoadedFiles map[string][]string
 }
 
 type Voice struct {
@@ -30,8 +32,16 @@ func (ctrl *ServerController) PostVoiceText(c *gin.Context) {
 
 	fmt.Println("Input text ---> '", voice.Text, "'")
 
-	if fileName, ok := ctrl.FileNames[voice.Text]; ok {
-		ctrl.Main.VChs.Ch <- fileName
+	if fileNames, ok := ctrl.LoadedFiles[voice.Text]; ok {
+		count := len(fileNames)
+		rand.Seed(time.Now().UnixNano())
+
+		randNum := 0
+		if count != 1 {
+			randNum = rand.Intn(count - 1)
+		}
+
+		ctrl.Main.VChs.Ch <- fileNames[randNum]
 	}
 
 }

--- a/router/mainRouter.go
+++ b/router/mainRouter.go
@@ -14,7 +14,7 @@ import (
 func InitMainRouter(config config.Config) (*discordgo.Session, *gin.Engine, error) {
 	ctrl := controller.GetMainController()
 
-	fileNames, err := loadAudioFiles(config)
+	loadedFiles, err := loadAudioFiles(config)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -24,15 +24,15 @@ func InitMainRouter(config config.Config) (*discordgo.Session, *gin.Engine, erro
 		return nil, nil, err
 	}
 
-	g := InitServerRouter(fileNames, ctrl)
+	g := InitServerRouter(loadedFiles, ctrl)
 
 	return dg, g, err
 }
 
-func loadAudioFiles(config config.Config) (map[string]string, error) {
+func loadAudioFiles(config config.Config) (map[string][]string, error) {
 	extension := ".wav"
 	ignoreSymbols := []string{"。", "、", ",", ".", "・", "_", "＿", "!", "！", "?", "？", " ", "　", "…"}
-	fileNames := map[string]string{}
+	loadedFiles := map[string][]string{}
 
 	fmt.Println("Loading sound file ...")
 	files, err := ioutil.ReadDir("sounds")
@@ -47,11 +47,11 @@ func loadAudioFiles(config config.Config) (map[string]string, error) {
 			for _, ignoreSymbol := range ignoreSymbols {
 				trimmedFileName = strings.ReplaceAll(trimmedFileName, ignoreSymbol, "")
 			}
-			fileNames[trimmedFileName] = fileName
+			loadedFiles[trimmedFileName] = append(loadedFiles[trimmedFileName], fileName)
 
 		}
 	}
 	fmt.Println("Sound file was Loaded!")
 
-	return fileNames, nil
+	return loadedFiles, nil
 }

--- a/router/serverRouter.go
+++ b/router/serverRouter.go
@@ -7,12 +7,12 @@ import (
 )
 
 // InitServer サーバの初期化
-func InitServerRouter(fileNames map[string]string, mctrl *controller.MainController) *gin.Engine {
+func InitServerRouter(loadedFiles map[string][]string, mctrl *controller.MainController) *gin.Engine {
 	r := gin.Default()
 	r.LoadHTMLGlob("templates/*.html")
 
 	ctrl := mctrl.GetServerController()
-	ctrl.FileNames = fileNames
+	ctrl.LoadedFiles = loadedFiles
 
 	r.GET("/recognition", ctrl.GetRecognition)
 	r.POST("/postVoiceText", ctrl.PostVoiceText)


### PR DESCRIPTION
#13 に関する修正。
map[string]string からmap[string][]stringにすることで、１つのkeyに対して複数のファイル名を保持できるようになった。
疑似乱数で再生するファイルが選択される。