### PR TITLE
Botの発言頻度を制限した

### DIFF
--- a/controller/mainController.go
+++ b/controller/mainController.go
@@ -1,12 +1,19 @@
 package controller
 
+import "sync"
+
 type MainController struct {
 	VChs  VoiceConnection
-	Clock bool
+	Timer Timer
 }
 
 type VoiceConnection struct {
 	Ch chan string
+}
+
+type Timer struct {
+	AllowSend bool
+	Lock      sync.Mutex
 }
 
 func (mctrl *MainController) GetDiscordController() *DiscordController {
@@ -20,6 +27,6 @@ func (mctrl *MainController) GetServerController() *ServerController {
 func GetMainController() *MainController {
 	ch := make(chan string)
 	vchs := VoiceConnection{Ch: ch}
-	clock := false
-	return &MainController{VChs: vchs, Clock: clock}
+	timer := Timer{}
+	return &MainController{VChs: vchs, Timer: timer}
 }

--- a/controller/serverController.go
+++ b/controller/serverController.go
@@ -26,7 +26,7 @@ func (ctrl *ServerController) GetRecognition(c *gin.Context) {
 }
 
 func (ctrl *ServerController) PostVoiceText(c *gin.Context) {
-	if ctrl.Main.Clock {
+	if ctrl.Main.Timer.AllowSend {
 		voice := Voice{}
 
 		err := c.ShouldBind(&voice)
@@ -55,7 +55,10 @@ func (ctrl *ServerController) PostVoiceText(c *gin.Context) {
 				}
 
 				ctrl.Main.VChs.Ch <- fileNames[randNum]
-				ctrl.Main.Clock = false
+
+				ctrl.Main.Timer.Lock.Lock()
+				ctrl.Main.Timer.AllowSend = false
+				ctrl.Main.Timer.Lock.Unlock()
 				break
 			}
 		}

--- a/router/mainRouter.go
+++ b/router/mainRouter.go
@@ -16,7 +16,7 @@ import (
 func InitMainRouter(config config.Config) (*discordgo.Session, *gin.Engine, error) {
 	ctrl := controller.GetMainController()
 
-	go Clock(ctrl)
+	go clock(ctrl)
 
 	loadedFiles, err := loadAudioFiles(config)
 	if err != nil {
@@ -63,9 +63,12 @@ func loadAudioFiles(config config.Config) (map[string][]string, error) {
 	return loadedFiles, nil
 }
 
-func Clock(ctrl *controller.MainController) {
+func clock(ctrl *controller.MainController) {
 	for {
+		ctrl.Timer.Lock.Lock()
+		ctrl.Timer.AllowSend = true
+		ctrl.Timer.Lock.Unlock()
+
 		time.Sleep(time.Second * 45)
-		ctrl.Clock = true
 	}
 }


### PR DESCRIPTION
#36 に関する変更。
Botのマシンガントークを阻止するため、指定の秒数以内には複数回の発言ができないようにした。