### PR TITLE
Bot側が受信していないときはChannelに投げられないようにした

### DIFF
--- a/controller/discordController.go
+++ b/controller/discordController.go
@@ -36,11 +36,19 @@ func (ctrl *DiscordController) MessageRecive(s *discordgo.Session, event *discor
 			//音声ファイルのリクエスト受付を開始
 			go playAudioLoop(s, ctrl)
 
+			ctrl.Main.VChs.Lock.Lock()
+			ctrl.Main.VChs.Condition = true //音声ファイル名の送信を許可
+			ctrl.Main.VChs.Lock.Unlock()
+
 		}
 	}
 
 	//VC退出
 	if event.Content == "おつかれさまです" {
+		ctrl.Main.VChs.Lock.Lock()
+		ctrl.Main.VChs.Condition = false //音声ファイル名の送信を遮断
+		ctrl.Main.VChs.Lock.Unlock()
+
 		s.ChannelMessageSend(discordChannel.ID, "それでは")
 		if err := ctrl.VC.Disconnect(); err != nil {
 			panic(err)

--- a/controller/mainController.go
+++ b/controller/mainController.go
@@ -1,11 +1,15 @@
 package controller
 
+import "sync"
+
 type MainController struct {
 	VChs VoiceConnection
 }
 
 type VoiceConnection struct {
-	Ch chan string
+	Ch        chan string
+	Condition bool
+	Lock      sync.Mutex
 }
 
 func (mctrl *MainController) GetDiscordController() *DiscordController {
@@ -18,6 +22,6 @@ func (mctrl *MainController) GetServerController() *ServerController {
 
 func GetMainController() *MainController {
 	ch := make(chan string)
-	vchs := VoiceConnection{Ch: ch}
+	vchs := VoiceConnection{Ch: ch, Condition: false}
 	return &MainController{VChs: vchs}
 }

--- a/controller/serverController.go
+++ b/controller/serverController.go
@@ -33,7 +33,7 @@ func (ctrl *ServerController) GetRecognition(c *gin.Context) {
 }
 
 func (ctrl *ServerController) PostVoiceText(c *gin.Context) {
-	if ctrl.Timer.AllowSend {
+	if ctrl.Timer.AllowSend && ctrl.Main.VChs.Condition {
 		voice := Voice{}
 
 		err := c.ShouldBind(&voice)


### PR DESCRIPTION
#6 に関する変更。
BotのVC非参加時にも音声ファイルのリクエストが可能な問題に対応。
mainControllerにVC参加状態を示す値をもたせた。

まだ動作確認できてないので、できたらmarge。